### PR TITLE
Add rates for 2023/2024, Upgrade Node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
       - run: yarn
       - run: yarn build
       - run: yarn lint

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 An ultra-fast, tiny TypeScript implementation of UK Income Tax & National Insurance calculations. See it in action on [SavingTool.co.uk](https://savingtool.co.uk).
 
-Multiple versions of the HMRC rates can be supported, although only 2022/23 has been implemented (see `src/hmrc.ts`).
+Multiple versions of the HMRC rates can be supported, although only the follwing years have been implemented:
 
-Works in all modern browsers and Node.js (v14+ LTS recommended).
+- 2022/23
+- 2023/24
+
+Works in all modern browsers and Node.js (v18+ LTS recommended).
 
 ## Installation
 
@@ -22,7 +25,7 @@ There are 5 main APIs:
 
 All APIs return raw amounts and there is no formatting or display functionality.
 
-Note that `taxYear` is an optional input to select which tax year rates should be used (default is "2022/23").
+Note that `taxYear` is an optional input to select which tax year rates should be used (default is "2023/24").
 
 ## Examples (2022/23 HMRC Rates)
 

--- a/src/hmrc.test.ts
+++ b/src/hmrc.test.ts
@@ -1,11 +1,15 @@
 import { getHmrcRates } from "./hmrc";
 
 describe("getHmrcRates", () => {
-  test("It uses default 2022/23 rates", () => {
+  test("It uses default 2023/24 rates", () => {
     expect(getHmrcRates().DEFAULT_PERSONAL_ALLOWANCE).toEqual(12570);
   });
 
   test("It uses explicit 2022/23 rates", () => {
     expect(getHmrcRates("2022/23").DEFAULT_PERSONAL_ALLOWANCE).toEqual(12570);
+  });
+
+  test("It uses explicit 2023/24 rates", () => {
+    expect(getHmrcRates("2023/24").DEFAULT_PERSONAL_ALLOWANCE).toEqual(12570);
   });
 });

--- a/src/hmrc.ts
+++ b/src/hmrc.ts
@@ -48,11 +48,31 @@ const taxRates: Record<TaxYear, TaxRates> = {
     NI_MIDDLE_BRACKET: 242,
     NI_UPPER_BRACKET: 967,
   },
+  // As of 6th April 2023
+  "2023/24": {
+    // Income tax
+    DEFAULT_PERSONAL_ALLOWANCE: 12_570,
+    HIGHER_BRACKET: 50_270,
+    ADDITIONAL_BRACKET: 124_140,
+    BASIC_RATE: 0.2,
+    HIGHER_RATE: 0.4,
+    ADDITIONAL_RATE: 0.45,
+    PERSONAL_ALLOWANCE_DROPOFF: 100_000,
+    // Student loan repayments
+    STUDENT_LOAN_PLAN_1_WEEKLY_THRESHOLD: 388,
+    STUDENT_LOAN_PLAN_2_WEEKLY_THRESHOLD: 524,
+    STUDENT_LOAN_REPAYMENT_AMOUNT: 0.09, // People on plans 1 or 2 repay 9% of the amount you earn over the threshold
+    // National Insurance
+    NI_MIDDLE_RATE: 0.12,
+    NI_UPPER_RATE: 0.02,
+    NI_MIDDLE_BRACKET: 242,
+    NI_UPPER_BRACKET: 967,
+  },
 };
 
 export const getHmrcRates = (taxYear?: TaxYear) => {
   if (!taxYear) {
-    return taxRates["2022/23"];
+    return taxRates["2023/24"];
   }
 
   return taxRates[taxYear];

--- a/src/incomeTax.test.ts
+++ b/src/incomeTax.test.ts
@@ -63,10 +63,15 @@ describe("calculateIncomeTax", () => {
     const { taxableAnnualIncome, basic, higher, additional } = expectation;
     test(taxableAnnualIncome.toString(), () => {
       const personalAllowance = calculatePersonalAllowance({
+        taxYear: "2022/23",
         taxableAnnualIncome,
       });
       expect(
-        calculateIncomeTax({ taxableAnnualIncome, personalAllowance })
+        calculateIncomeTax({
+          taxYear: "2022/23",
+          taxableAnnualIncome,
+          personalAllowance,
+        })
       ).toEqual({
         basicRateTax: basic,
         higherRateTax: higher,

--- a/src/nationalInsurance.test.ts
+++ b/src/nationalInsurance.test.ts
@@ -26,7 +26,10 @@ describe("calculateEmployeeNationalInsurance", () => {
     const { taxableAnnualIncome, nics } = expectation;
     test(taxableAnnualIncome.toString(), () => {
       expect(
-        calculateEmployeeNationalInsurance({ taxableAnnualIncome })
+        calculateEmployeeNationalInsurance({
+          taxYear: "2022/23",
+          taxableAnnualIncome,
+        })
       ).toEqual(nics);
     });
   });

--- a/src/personalAllowance.test.ts
+++ b/src/personalAllowance.test.ts
@@ -29,9 +29,9 @@ describe("calculatePersonalAllowance", () => {
   expectations.forEach((expectation) => {
     const { taxableAnnualIncome, allowance } = expectation;
     test(taxableAnnualIncome.toString(), () => {
-      expect(calculatePersonalAllowance({ taxableAnnualIncome })).toEqual(
-        allowance
-      );
+      expect(
+        calculatePersonalAllowance({ taxYear: "2022/23", taxableAnnualIncome })
+      ).toEqual(allowance);
     });
   });
 });

--- a/src/studentLoan.test.ts
+++ b/src/studentLoan.test.ts
@@ -32,6 +32,7 @@ describe("calculateStudentLoanRepayments", () => {
       test(taxableAnnualIncome.toString(), () => {
         expect(
           calculateStudentLoanRepayments({
+            taxYear: "2022/23",
             taxableAnnualIncome,
             studentLoanPlanNo: 1,
           })

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,4 +6,4 @@ export interface IncomeTax {
 
 export type StudentLoanPlan = 1 | 2;
 
-export type TaxYear = "2022/23";
+export type TaxYear = "2022/23" | "2023/24";


### PR DESCRIPTION
- Adds 2023/24 tax rates
- Made 2023/24 the new default
- Upgrade the project to use newer versions of Node

HMRC Changes that came in on 6th April:

- Income tax: additional rate bracket down by £25k
- NICs: NHS levy expired