### PR TITLE
Correct how higher and additional rate tax is calculated

### DIFF
--- a/src/incomeTax.test.ts
+++ b/src/incomeTax.test.ts
@@ -12,49 +12,54 @@ const expectations = [
   { taxableAnnualIncome: 60_000, basic: 7540, higher: 3892, additional: 0 },
   { taxableAnnualIncome: 75_000, basic: 7540, higher: 9892, additional: 0 },
   { taxableAnnualIncome: 90_000, basic: 7540, higher: 15892, additional: 0 },
-  { taxableAnnualIncome: 110_000, basic: 8540, higher: 25892, additional: 0 },
-  { taxableAnnualIncome: 130_000, basic: 10054, higher: 36920, additional: 0 },
+  { taxableAnnualIncome: 110_000, basic: 8540, higher: 23892, additional: 0 },
+  {
+    taxableAnnualIncome: 130_000,
+    basic: 10054,
+    higher: 29548,
+    additional: 2637,
+  },
   {
     taxableAnnualIncome: 145_000,
     basic: 10054,
-    higher: 39892,
-    additional: 3406.5,
+    higher: 29548,
+    additional: 9387,
   },
   {
     taxableAnnualIncome: 160_000,
     basic: 10054,
-    higher: 39892,
-    additional: 10156.5,
+    higher: 29548,
+    additional: 16137,
   },
   {
     taxableAnnualIncome: 175_000,
     basic: 10054,
-    higher: 39892,
-    additional: 16906.5,
+    higher: 29548,
+    additional: 22887,
   },
   {
     taxableAnnualIncome: 200_000,
     basic: 10054,
-    higher: 39892,
-    additional: 28156.5,
+    higher: 29548,
+    additional: 34137,
   },
   {
     taxableAnnualIncome: 250_000,
     basic: 10054,
-    higher: 39892,
-    additional: 50656.5,
+    higher: 29548,
+    additional: 56637,
   },
   {
     taxableAnnualIncome: 500_000,
     basic: 10054,
-    higher: 39892,
-    additional: 163156.5,
+    higher: 29548,
+    additional: 169137,
   },
   {
     taxableAnnualIncome: 1_000_000,
     basic: 10054,
-    higher: 39892,
-    additional: 388156.5,
+    higher: 29548,
+    additional: 394137,
   },
 ];
 
@@ -63,11 +68,11 @@ describe("calculateIncomeTax", () => {
     const { taxableAnnualIncome, basic, higher, additional } = expectation;
     test(taxableAnnualIncome.toString(), () => {
       const personalAllowance = calculatePersonalAllowance({
-        taxYear: "2022/23",
+        taxYear: "2023/24",
         taxableAnnualIncome,
       });
       const taxAmounts = calculateIncomeTax({
-        taxYear: "2022/23",
+        taxYear: "2023/24",
         taxableAnnualIncome,
         personalAllowance,
       });

--- a/src/incomeTax.test.ts
+++ b/src/incomeTax.test.ts
@@ -12,47 +12,47 @@ const expectations = [
   { taxableAnnualIncome: 60_000, basic: 7540, higher: 3892, additional: 0 },
   { taxableAnnualIncome: 75_000, basic: 7540, higher: 9892, additional: 0 },
   { taxableAnnualIncome: 90_000, basic: 7540, higher: 15892, additional: 0 },
-  { taxableAnnualIncome: 110_000, basic: 7540, higher: 25892, additional: 0 },
-  { taxableAnnualIncome: 130_000, basic: 7540, higher: 36920, additional: 0 },
+  { taxableAnnualIncome: 110_000, basic: 8540, higher: 25892, additional: 0 },
+  { taxableAnnualIncome: 130_000, basic: 10054, higher: 36920, additional: 0 },
   {
     taxableAnnualIncome: 145_000,
-    basic: 7540,
+    basic: 10054,
     higher: 39892,
     additional: 3406.5,
   },
   {
     taxableAnnualIncome: 160_000,
-    basic: 7540,
+    basic: 10054,
     higher: 39892,
     additional: 10156.5,
   },
   {
     taxableAnnualIncome: 175_000,
-    basic: 7540,
+    basic: 10054,
     higher: 39892,
     additional: 16906.5,
   },
   {
     taxableAnnualIncome: 200_000,
-    basic: 7540,
+    basic: 10054,
     higher: 39892,
     additional: 28156.5,
   },
   {
     taxableAnnualIncome: 250_000,
-    basic: 7540,
+    basic: 10054,
     higher: 39892,
     additional: 50656.5,
   },
   {
     taxableAnnualIncome: 500_000,
-    basic: 7540,
+    basic: 10054,
     higher: 39892,
     additional: 163156.5,
   },
   {
     taxableAnnualIncome: 1_000_000,
-    basic: 7540,
+    basic: 10054,
     higher: 39892,
     additional: 388156.5,
   },
@@ -66,13 +66,12 @@ describe("calculateIncomeTax", () => {
         taxYear: "2022/23",
         taxableAnnualIncome,
       });
-      expect(
-        calculateIncomeTax({
-          taxYear: "2022/23",
-          taxableAnnualIncome,
-          personalAllowance,
-        })
-      ).toEqual({
+      const taxAmounts = calculateIncomeTax({
+        taxYear: "2022/23",
+        taxableAnnualIncome,
+        personalAllowance,
+      });
+      expect(taxAmounts).toEqual({
         basicRateTax: basic,
         higherRateTax: higher,
         additionalRateTax: additional,

--- a/src/incomeTax.ts
+++ b/src/incomeTax.ts
@@ -24,9 +24,6 @@ export const calculateIncomeTax = ({
     taxableAnnualIncome - personalAllowance > 0
       ? taxableAnnualIncome - personalAllowance
       : 0;
-  let basicRateTax = 0;
-  let higherRateTax = 0;
-  let additionalRateTax = 0;
 
   // Income over £100k: the brackets need to move in accordance with personal allowance changes
   const personalAllowanceDeduction =
@@ -34,47 +31,58 @@ export const calculateIncomeTax = ({
   const higherBracket = HIGHER_BRACKET - personalAllowanceDeduction;
   const additionalBracket = ADDITIONAL_BRACKET - personalAllowanceDeduction;
 
-  // Over £150k
+  // Additional Rate taxpayers
   if (taxableAnnualIncome > additionalBracket) {
     // 3 rates apply (basic, higher, additional)
     const additionalSection = taxableAnnualIncome - additionalBracket;
     const higherSection =
       taxableAnnualIncome - higherBracket - additionalSection;
-    const basicSection =
-      taxableAnnualIncome -
-      personalAllowance -
-      additionalSection -
-      higherSection;
-    basicRateTax = basicSection * BASIC_RATE;
-    higherRateTax = higherSection * HIGHER_RATE;
-    additionalRateTax = additionalSection * ADDITIONAL_RATE;
+    const basicSection = HIGHER_BRACKET - personalAllowance;
+    const basicRateTax = basicSection * BASIC_RATE;
+    const higherRateTax = higherSection * HIGHER_RATE;
+    const additionalRateTax = additionalSection * ADDITIONAL_RATE;
+
+    return {
+      basicRateTax,
+      higherRateTax,
+      additionalRateTax,
+    };
   }
 
-  // Over £50k
+  // Higher Rate taxpayers
   if (
     taxableAnnualIncome <= additionalBracket &&
     taxableAnnualIncome > higherBracket
   ) {
     // 2 bands apply (basic, higher)
     const higherSection = taxableAnnualIncome - higherBracket;
-    const basicSection =
-      taxableAnnualIncome - personalAllowance - higherSection;
-    basicRateTax = basicSection * BASIC_RATE;
-    higherRateTax = higherSection * HIGHER_RATE;
+    // const basicSection =
+    //   taxableAnnualIncome - personalAllowance - higherSection;
+    const basicSection = HIGHER_BRACKET - personalAllowance;
+    const basicRateTax = basicSection * BASIC_RATE;
+    const higherRateTax = higherSection * HIGHER_RATE;
+
+    return {
+      basicRateTax,
+      higherRateTax,
+      additionalRateTax: 0,
+    };
   }
 
-  // All salaries under £50k
+  // Basic Rate taxpayers
   if (
     taxableAnnualIncome <= higherBracket &&
     taxableAnnualIncome > personalAllowance
   ) {
     // 1 band applies (basic)
-    basicRateTax = afterPersonalAllowance * BASIC_RATE;
+    const basicRateTax = afterPersonalAllowance * BASIC_RATE;
+
+    return {
+      basicRateTax,
+      higherRateTax: 0,
+      additionalRateTax: 0,
+    };
   }
 
-  return {
-    basicRateTax,
-    higherRateTax,
-    additionalRateTax,
-  };
+  throw new Error("Unexpected Input");
 };

--- a/src/incomeTax.ts
+++ b/src/incomeTax.ts
@@ -37,7 +37,7 @@ export const calculateIncomeTax = ({
     // Taxable income over the additional bracket
     const additionalSection = taxableAnnualIncome - ADDITIONAL_BRACKET;
 
-    // Calculat amounts against sections
+    // Calculate amounts against sections
     const basicRateTax = basicSection * BASIC_RATE;
     const higherRateTax = higherSection * HIGHER_RATE;
     const additionalRateTax = additionalSection * ADDITIONAL_RATE;


### PR DESCRIPTION
Some investigation uncovered that the way higher and additional rate taxes were being calculated is incorrect. The proportions of income being taxed at the relevant bands wasn't right. For example, basic rate tax was being under-calculated for earners over £100k due to failing to account for the personal allowance correctly.

The worst impact of this was approx £2-3k of tax in a tax year.

This change:

1. Ensures sections of income are correctly apportioned before calculating the amount of tax due
2. Updates the test suite to reflect these changes, but also upgrades to 2023/24 tax rates