### PR TITLE
Add 2024/25 rates after Spring Budget 2024

### DIFF
--- a/src/hmrc.ts
+++ b/src/hmrc.ts
@@ -47,8 +47,8 @@ const taxRates: Record<TaxYear, TaxRates> = {
     STUDENT_LOAN_PLAN_2_WEEKLY_THRESHOLD: 524,
     STUDENT_LOAN_PLAN_4_WEEKLY_THRESHOLD: 487.98,
     STUDENT_LOAN_PLAN_5_WEEKLY_THRESHOLD: 480, // Note: this was only introduced in 2023/24, so technically isn't relevant to 22/23
-    STUDENT_LOAN_POSTGRAD_WEEKLY_THRESHOLD: 403.84,
     STUDENT_LOAN_REPAYMENT_AMOUNT: 0.09, // People on plans 1 or 2 repay 9% of the amount you earn over the threshold
+    STUDENT_LOAN_POSTGRAD_WEEKLY_THRESHOLD: 403.84,
     STUDENT_LOAN_REPAYMENT_AMOUNT_POSTGRAD: 0.06, // People on postgrad plans repay 6% of the amount you earn over the threshold
     // National Insurance
     NI_MIDDLE_RATE: 0.1325,
@@ -56,7 +56,6 @@ const taxRates: Record<TaxYear, TaxRates> = {
     NI_MIDDLE_BRACKET: 242,
     NI_UPPER_BRACKET: 967,
   },
-  // As of 6th April 2023
   "2023/24": {
     // Income tax
     DEFAULT_PERSONAL_ALLOWANCE: 12_570,
@@ -71,11 +70,34 @@ const taxRates: Record<TaxYear, TaxRates> = {
     STUDENT_LOAN_PLAN_2_WEEKLY_THRESHOLD: 524,
     STUDENT_LOAN_PLAN_4_WEEKLY_THRESHOLD: 532,
     STUDENT_LOAN_PLAN_5_WEEKLY_THRESHOLD: 480,
-    STUDENT_LOAN_POSTGRAD_WEEKLY_THRESHOLD: 403,
     STUDENT_LOAN_REPAYMENT_AMOUNT: 0.09, // People on plans 1, 2, 4 + 5 repay 9% of the amount you earn over the threshold
+    STUDENT_LOAN_POSTGRAD_WEEKLY_THRESHOLD: 403,
     STUDENT_LOAN_REPAYMENT_AMOUNT_POSTGRAD: 0.06, // People on postgrad plans repay 6% of the amount you earn over the threshold
     // National Insurance
     NI_MIDDLE_RATE: 0.1, // Changed from 12% to 10% on 6th Jan 2024 (out of normal cycle)
+    NI_UPPER_RATE: 0.02,
+    NI_MIDDLE_BRACKET: 242,
+    NI_UPPER_BRACKET: 967,
+  },
+  "2024/25": {
+    // Income tax
+    DEFAULT_PERSONAL_ALLOWANCE: 12_570,
+    HIGHER_BRACKET: 50_270,
+    ADDITIONAL_BRACKET: 125_140,
+    BASIC_RATE: 0.2,
+    HIGHER_RATE: 0.4,
+    ADDITIONAL_RATE: 0.45,
+    PERSONAL_ALLOWANCE_DROPOFF: 100_000,
+    // Student loan repayments
+    STUDENT_LOAN_PLAN_1_WEEKLY_THRESHOLD: 480.57,
+    STUDENT_LOAN_PLAN_2_WEEKLY_THRESHOLD: 524.9,
+    STUDENT_LOAN_PLAN_4_WEEKLY_THRESHOLD: 531.92,
+    STUDENT_LOAN_PLAN_5_WEEKLY_THRESHOLD: 480,
+    STUDENT_LOAN_REPAYMENT_AMOUNT: 0.09, // People on plans 1, 2, 4 + 5 repay 9% of the amount you earn over the threshold
+    STUDENT_LOAN_POSTGRAD_WEEKLY_THRESHOLD: 403.84,
+    STUDENT_LOAN_REPAYMENT_AMOUNT_POSTGRAD: 0.06, // People on postgrad plans repay 6% of the amount you earn over the threshold
+    // National Insurance
+    NI_MIDDLE_RATE: 0.08,
     NI_UPPER_RATE: 0.02,
     NI_MIDDLE_BRACKET: 242,
     NI_UPPER_BRACKET: 967,

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,4 +6,4 @@ export interface IncomeTax {
 
 export type StudentLoanPlan = 1 | 2 | 4 | 5 | "postgrad";
 
-export type TaxYear = "2022/23" | "2023/24";
+export type TaxYear = "2022/23" | "2023/24" | "2024/25";


### PR DESCRIPTION
- Most rates are the same as 23/24, but I made some of the thresholds more accurate (to the penny instead of pound)
- Main change: another 2% cut to main NI rate
- Student loan plan 1 threshold went up a bit

Source used: https://www.gov.uk/guidance/rates-and-thresholds-for-employers-2024-to-2025 