### PR TITLE
Add rates for the 2025/26 tax year, make it the new default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ Multiple versions of the HMRC rates can be supported, although only the follwing
 
 England/NI/Wales:
 
-- 2024/25 (default)
+- 2025/26 (default)
+- 2024/25
 - 2023/24
 - 2022/23
 
 Scotland:
 
-- 2024/25 (default)
+- 2025/26 (default)
+- 2024/25
 
 Works in all modern browsers and Node.js (LTS recommended).
 
@@ -32,7 +34,7 @@ Run: `yarn add @saving-tool/hmrc-income-tax` (or `npm install @saving-tool/hmrc-
 
 `country` is an optional input for all APIs: `"England/NI/Wales" | "Scotland"`. If not provided, the default is `"England/NI/Wales"`.
 
-Note that `taxYear` is an optional input to select which tax year rates should be used (default is "2024/25").
+Note that `taxYear` is an optional input to select which tax year rates should be used (default is "2025/26").
 
 ### `calculatePersonalAllowance`
 

--- a/src/hmrc.ts
+++ b/src/hmrc.ts
@@ -94,6 +94,34 @@ const englandNiWalesTaxRates: Record<SupportedEnglishTaxYear, EnglishTaxRates> =
       PENSION_MINIMUM_ANNUAL_ALLOWANCE: 10_000,
       PENSION_ADJUSTED_LIMIT: 260_000,
     },
+    "2025/26": {
+      COUNTRY: "England/NI/Wales",
+      // Income tax
+      DEFAULT_PERSONAL_ALLOWANCE: 12_570,
+      HIGHER_BRACKET: 50_270,
+      ADDITIONAL_BRACKET: 125_140,
+      BASIC_RATE: 0.2,
+      HIGHER_RATE: 0.4,
+      ADDITIONAL_RATE: 0.45,
+      PERSONAL_ALLOWANCE_DROPOFF: 100_000,
+      // Student loan repayments
+      STUDENT_LOAN_PLAN_1_WEEKLY_THRESHOLD: 501,
+      STUDENT_LOAN_PLAN_2_WEEKLY_THRESHOLD: 547,
+      STUDENT_LOAN_PLAN_4_WEEKLY_THRESHOLD: 629,
+      STUDENT_LOAN_PLAN_5_WEEKLY_THRESHOLD: 480,
+      STUDENT_LOAN_REPAYMENT_AMOUNT: 0.09, // People on plans 1, 2, 4 + 5 repay 9% of the amount you earn over the threshold
+      STUDENT_LOAN_POSTGRAD_WEEKLY_THRESHOLD: 403,
+      STUDENT_LOAN_REPAYMENT_AMOUNT_POSTGRAD: 0.06, // People on postgrad plans repay 6% of the amount you earn over the threshold
+      // National Insurance
+      NI_MIDDLE_RATE: 0.08,
+      NI_UPPER_RATE: 0.02,
+      NI_MIDDLE_BRACKET: 242,
+      NI_UPPER_BRACKET: 967,
+      // Pension allowances
+      PENSION_ANNUAL_ALLOWANCE: 60_000,
+      PENSION_MINIMUM_ANNUAL_ALLOWANCE: 10_000,
+      PENSION_ADJUSTED_LIMIT: 260_000,
+    },
   };
 
 const scottishTaxRates: Record<SupportedScottishTaxYear, ScottishTaxRates> = {
@@ -135,6 +163,43 @@ const scottishTaxRates: Record<SupportedScottishTaxYear, ScottishTaxRates> = {
     PENSION_MINIMUM_ANNUAL_ALLOWANCE: 10_000,
     PENSION_ADJUSTED_LIMIT: 260_000,
   },
+  "2025/26": {
+    COUNTRY: "Scotland",
+
+    // Income tax
+    DEFAULT_PERSONAL_ALLOWANCE: 12_570,
+
+    STARTER_RATE: 0.19,
+    BASIC_BRACKET: 15_398,
+    BASIC_RATE: 0.2,
+    INTERMEDIATE_BRACKET: 27_492,
+    INTERMEDIATE_RATE: 0.21,
+    HIGHER_BRACKET: 43_663,
+    HIGHER_RATE: 0.42,
+    ADVANCED_BRACKET: 75_001,
+    ADVANCED_RATE: 0.45,
+    TOP_BRACKET: 125_140,
+    TOP_RATE: 0.48,
+
+    PERSONAL_ALLOWANCE_DROPOFF: 100_000,
+    // Student loan repayments
+    STUDENT_LOAN_PLAN_1_WEEKLY_THRESHOLD: 480.57,
+    STUDENT_LOAN_PLAN_2_WEEKLY_THRESHOLD: 524.9,
+    STUDENT_LOAN_PLAN_4_WEEKLY_THRESHOLD: 531.92,
+    STUDENT_LOAN_PLAN_5_WEEKLY_THRESHOLD: 480,
+    STUDENT_LOAN_REPAYMENT_AMOUNT: 0.09, // People on plans 1, 2, 4 + 5 repay 9% of the amount you earn over the threshold
+    STUDENT_LOAN_POSTGRAD_WEEKLY_THRESHOLD: 403.84,
+    STUDENT_LOAN_REPAYMENT_AMOUNT_POSTGRAD: 0.06, // People on postgrad plans repay 6% of the amount you earn over the threshold
+    // National Insurance
+    NI_MIDDLE_RATE: 0.08,
+    NI_UPPER_RATE: 0.02,
+    NI_MIDDLE_BRACKET: 242,
+    NI_UPPER_BRACKET: 967,
+    // Pension allowances
+    PENSION_ANNUAL_ALLOWANCE: 60_000,
+    PENSION_MINIMUM_ANNUAL_ALLOWANCE: 10_000,
+    PENSION_ADJUSTED_LIMIT: 260_000,
+  },
 };
 
 interface Options {
@@ -147,7 +212,7 @@ export const getHmrcRates = (
 ): EnglishTaxRates | ScottishTaxRates => {
   const taxRates =
     options?.country === "Scotland" ? scottishTaxRates : englandNiWalesTaxRates;
-  const taxYearToUse = options?.taxYear ?? "2024/25";
+  const taxYearToUse = options?.taxYear ?? "2025/26";
 
   if (!taxRates.hasOwnProperty(taxYearToUse)) {
     throw new Error(

--- a/src/hmrc.ts
+++ b/src/hmrc.ts
@@ -183,12 +183,12 @@ const scottishTaxRates: Record<SupportedScottishTaxYear, ScottishTaxRates> = {
 
     PERSONAL_ALLOWANCE_DROPOFF: 100_000,
     // Student loan repayments
-    STUDENT_LOAN_PLAN_1_WEEKLY_THRESHOLD: 480.57,
-    STUDENT_LOAN_PLAN_2_WEEKLY_THRESHOLD: 524.9,
-    STUDENT_LOAN_PLAN_4_WEEKLY_THRESHOLD: 531.92,
+    STUDENT_LOAN_PLAN_1_WEEKLY_THRESHOLD: 501,
+    STUDENT_LOAN_PLAN_2_WEEKLY_THRESHOLD: 547,
+    STUDENT_LOAN_PLAN_4_WEEKLY_THRESHOLD: 629,
     STUDENT_LOAN_PLAN_5_WEEKLY_THRESHOLD: 480,
     STUDENT_LOAN_REPAYMENT_AMOUNT: 0.09, // People on plans 1, 2, 4 + 5 repay 9% of the amount you earn over the threshold
-    STUDENT_LOAN_POSTGRAD_WEEKLY_THRESHOLD: 403.84,
+    STUDENT_LOAN_POSTGRAD_WEEKLY_THRESHOLD: 403,
     STUDENT_LOAN_REPAYMENT_AMOUNT_POSTGRAD: 0.06, // People on postgrad plans repay 6% of the amount you earn over the threshold
     // National Insurance
     NI_MIDDLE_RATE: 0.08,

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,9 +23,13 @@ export interface ScottishIncomeTax {
 
 export type StudentLoanPlan = 1 | 2 | 4 | 5 | "postgrad";
 
-export type SupportedEnglishTaxYear = "2022/23" | "2023/24" | "2024/25";
+export type SupportedEnglishTaxYear =
+  | "2022/23"
+  | "2023/24"
+  | "2024/25"
+  | "2025/26";
 
-export type SupportedScottishTaxYear = "2024/25";
+export type SupportedScottishTaxYear = "2024/25" | "2025/26";
 
 export type TaxYear = SupportedEnglishTaxYear | SupportedScottishTaxYear;
 


### PR DESCRIPTION
Not much changed because of many rates being frozen but

1. Student loan repayment threshold amounts updated (increased a bit)
2. The threshold amounts for basic rate and intermediate rate income tax in scotland were increased slightly