### PR TITLE
[Breaking] Change parameter names so that they are unambiguous

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 src
 coverage
+.claude
 .vscode
 .github
 node_modules

--- a/README.md
+++ b/README.md
@@ -142,25 +142,29 @@ This cumulative mode implements HMRC PAYE rules where personal allowances are pr
 
 ### `calculateEmployeeNationalInsurance`
 
-Calculates the National Insurance contributions due in a tax year on an individual's taxable income, single amount. Note: only supports class 1, category A.
+Calculates the National Insurance contributions due in a tax year on an individual's gross employment income, single amount. Note: only supports class 1, category A.
+
+Pass gross PAYE employment income. Unlike income tax, NI is not reduced by non-salary-sacrifice pension contributions.
 
 ```typescript
 calculateEmployeeNationalInsurance({
   taxYear?: TaxYear,
   country?: Country,
-  taxableAnnualIncome: number
+  grossAnnualIncome: number // gross PAYE employment income, before any non-salary-sacrifice pension deductions
 }) => number;
 ```
 
 ### `calculateEmployerNationalInsurance`
 
-Calculates the employer National Insurance contributions due in a tax year on an employee's taxable income. Note: only supports class 1, category A secondary contributions.
+Calculates the employer National Insurance contributions due in a tax year on an employee's gross employment income. Note: only supports class 1, category A secondary contributions.
+
+Pass gross PAYE employment income. Unlike income tax, NI is not reduced by non-salary-sacrifice pension contributions.
 
 ```typescript
 calculateEmployerNationalInsurance({
   taxYear?: TaxYear,
   country?: Country,
-  taxableAnnualIncome: number
+  grossAnnualIncome: number // gross PAYE employment income, before any non-salary-sacrifice pension deductions
 }) => number;
 ```
 
@@ -213,13 +217,15 @@ calculateDividendTax({
 
 ### `calculateStudentLoanRepayments`
 
-Calculates the student loan repayments due in a tax year on an individual's taxable income, single amount.
+Calculates the student loan repayments due in a tax year on an individual's gross employment income, single amount.
+
+Pass gross PAYE employment income. Like NI, student loan repayments are not reduced by non-salary-sacrifice pension contributions.
 
 ```typescript
 calculateStudentLoanRepayments({
   taxYear?: TaxYear,
   country?: Country,
-  taxableAnnualIncome: number,
+  grossAnnualIncome: number, // gross PAYE employment income, before any non-salary-sacrifice pension deductions
   studentLoanPlanNo: 1 | 2 | 4 | 5 | 'postgrad'
 }) => number;
 ```

--- a/src/nationalInsurance.test.ts
+++ b/src/nationalInsurance.test.ts
@@ -4,34 +4,34 @@ import {
 } from "./nationalInsurance";
 
 const expectationsA = [
-  { taxableAnnualIncome: 15_000, nics: 320.11999999999995 },
-  { taxableAnnualIncome: 17_500, nics: 651.3700000000001 },
-  { taxableAnnualIncome: 20_000, nics: 982.6200000000002 },
-  { taxableAnnualIncome: 22_500, nics: 1313.87 },
-  { taxableAnnualIncome: 25_000, nics: 1645.1200000000001 },
-  { taxableAnnualIncome: 50_000, nics: 4957.620000000001 },
-  { taxableAnnualIncome: 55_000, nics: 5148.5199999999995 },
-  { taxableAnnualIncome: 60_000, nics: 5311.02 },
-  { taxableAnnualIncome: 75_000, nics: 5798.52 },
-  { taxableAnnualIncome: 90_000, nics: 6286.0199999999995 },
-  { taxableAnnualIncome: 110_000, nics: 6936.0199999999995 },
-  { taxableAnnualIncome: 130_000, nics: 7586.0199999999995 },
-  { taxableAnnualIncome: 150_000, nics: 8236.02 },
-  { taxableAnnualIncome: 175_000, nics: 9048.52 },
-  { taxableAnnualIncome: 200_000, nics: 9861.02 },
-  { taxableAnnualIncome: 250_000, nics: 11486.02 },
-  { taxableAnnualIncome: 500_000, nics: 19611.02 },
-  { taxableAnnualIncome: 1_000_000, nics: 35861.02 },
+  { grossAnnualIncome: 15_000, nics: 320.11999999999995 },
+  { grossAnnualIncome: 17_500, nics: 651.3700000000001 },
+  { grossAnnualIncome: 20_000, nics: 982.6200000000002 },
+  { grossAnnualIncome: 22_500, nics: 1313.87 },
+  { grossAnnualIncome: 25_000, nics: 1645.1200000000001 },
+  { grossAnnualIncome: 50_000, nics: 4957.620000000001 },
+  { grossAnnualIncome: 55_000, nics: 5148.5199999999995 },
+  { grossAnnualIncome: 60_000, nics: 5311.02 },
+  { grossAnnualIncome: 75_000, nics: 5798.52 },
+  { grossAnnualIncome: 90_000, nics: 6286.0199999999995 },
+  { grossAnnualIncome: 110_000, nics: 6936.0199999999995 },
+  { grossAnnualIncome: 130_000, nics: 7586.0199999999995 },
+  { grossAnnualIncome: 150_000, nics: 8236.02 },
+  { grossAnnualIncome: 175_000, nics: 9048.52 },
+  { grossAnnualIncome: 200_000, nics: 9861.02 },
+  { grossAnnualIncome: 250_000, nics: 11486.02 },
+  { grossAnnualIncome: 500_000, nics: 19611.02 },
+  { grossAnnualIncome: 1_000_000, nics: 35861.02 },
 ];
 
 describe("calculateEmployeeNationalInsurance (22/23)", () => {
   expectationsA.forEach((expectation) => {
-    const { taxableAnnualIncome, nics } = expectation;
-    test(taxableAnnualIncome.toString(), () => {
+    const { grossAnnualIncome, nics } = expectation;
+    test(grossAnnualIncome.toString(), () => {
       expect(
         calculateEmployeeNationalInsurance({
           taxYear: "2022/23",
-          taxableAnnualIncome,
+          grossAnnualIncome,
         })
       ).toBeCloseTo(nics, 1);
     });
@@ -39,34 +39,34 @@ describe("calculateEmployeeNationalInsurance (22/23)", () => {
 });
 
 const expectationsB = [
-  { taxableAnnualIncome: 15_000, nics: 241.59 },
-  { taxableAnnualIncome: 17_500, nics: 491.6 },
-  { taxableAnnualIncome: 20_000, nics: 741.6 },
-  { taxableAnnualIncome: 22_500, nics: 991.59 },
-  { taxableAnnualIncome: 25_000, nics: 1241.6 },
-  { taxableAnnualIncome: 50_000, nics: 3741.6 },
-  { taxableAnnualIncome: 55_000, nics: 3864.32 },
-  { taxableAnnualIncome: 60_000, nics: 3964.32 },
-  { taxableAnnualIncome: 75_000, nics: 4264.32 },
-  { taxableAnnualIncome: 90_000, nics: 4564.32 },
-  { taxableAnnualIncome: 110_000, nics: 4964.32 },
-  { taxableAnnualIncome: 130_000, nics: 5364.32 },
-  { taxableAnnualIncome: 150_000, nics: 5764.32 },
-  { taxableAnnualIncome: 175_000, nics: 6264.32 },
-  { taxableAnnualIncome: 200_000, nics: 6764.32 },
-  { taxableAnnualIncome: 250_000, nics: 7764.32 },
-  { taxableAnnualIncome: 500_000, nics: 12764.32 },
-  { taxableAnnualIncome: 1_000_000, nics: 22764.32 },
+  { grossAnnualIncome: 15_000, nics: 241.59 },
+  { grossAnnualIncome: 17_500, nics: 491.6 },
+  { grossAnnualIncome: 20_000, nics: 741.6 },
+  { grossAnnualIncome: 22_500, nics: 991.59 },
+  { grossAnnualIncome: 25_000, nics: 1241.6 },
+  { grossAnnualIncome: 50_000, nics: 3741.6 },
+  { grossAnnualIncome: 55_000, nics: 3864.32 },
+  { grossAnnualIncome: 60_000, nics: 3964.32 },
+  { grossAnnualIncome: 75_000, nics: 4264.32 },
+  { grossAnnualIncome: 90_000, nics: 4564.32 },
+  { grossAnnualIncome: 110_000, nics: 4964.32 },
+  { grossAnnualIncome: 130_000, nics: 5364.32 },
+  { grossAnnualIncome: 150_000, nics: 5764.32 },
+  { grossAnnualIncome: 175_000, nics: 6264.32 },
+  { grossAnnualIncome: 200_000, nics: 6764.32 },
+  { grossAnnualIncome: 250_000, nics: 7764.32 },
+  { grossAnnualIncome: 500_000, nics: 12764.32 },
+  { grossAnnualIncome: 1_000_000, nics: 22764.32 },
 ];
 
 describe("calculateEmployeeNationalInsurance (23/24)", () => {
   expectationsB.forEach((expectation) => {
-    const { taxableAnnualIncome, nics } = expectation;
-    test(taxableAnnualIncome.toString(), () => {
+    const { grossAnnualIncome, nics } = expectation;
+    test(grossAnnualIncome.toString(), () => {
       expect(
         calculateEmployeeNationalInsurance({
           taxYear: "2023/24",
-          taxableAnnualIncome,
+          grossAnnualIncome,
         })
       ).toBeCloseTo(nics, 1);
     });
@@ -74,34 +74,34 @@ describe("calculateEmployeeNationalInsurance (23/24)", () => {
 });
 
 const expectationsC = [
-  { taxableAnnualIncome: 15_000, nics: 193.28 },
-  { taxableAnnualIncome: 17_500, nics: 393.28 },
-  { taxableAnnualIncome: 20_000, nics: 593.28 },
-  { taxableAnnualIncome: 22_500, nics: 793.28 },
-  { taxableAnnualIncome: 25_000, nics: 993.28 },
-  { taxableAnnualIncome: 50_000, nics: 2993.28 },
-  { taxableAnnualIncome: 55_000, nics: 3110.32 },
-  { taxableAnnualIncome: 60_000, nics: 3210.32 },
-  { taxableAnnualIncome: 75_000, nics: 3510.32 },
-  { taxableAnnualIncome: 90_000, nics: 3810.32 },
-  { taxableAnnualIncome: 110_000, nics: 4210.32 },
-  { taxableAnnualIncome: 130_000, nics: 4610.32 },
-  { taxableAnnualIncome: 150_000, nics: 5010.32 },
-  { taxableAnnualIncome: 175_000, nics: 5510.32 },
-  { taxableAnnualIncome: 200_000, nics: 6010.32 },
-  { taxableAnnualIncome: 250_000, nics: 7010.32 },
-  { taxableAnnualIncome: 500_000, nics: 12010.32 },
-  { taxableAnnualIncome: 1_000_000, nics: 22010.32 },
+  { grossAnnualIncome: 15_000, nics: 193.28 },
+  { grossAnnualIncome: 17_500, nics: 393.28 },
+  { grossAnnualIncome: 20_000, nics: 593.28 },
+  { grossAnnualIncome: 22_500, nics: 793.28 },
+  { grossAnnualIncome: 25_000, nics: 993.28 },
+  { grossAnnualIncome: 50_000, nics: 2993.28 },
+  { grossAnnualIncome: 55_000, nics: 3110.32 },
+  { grossAnnualIncome: 60_000, nics: 3210.32 },
+  { grossAnnualIncome: 75_000, nics: 3510.32 },
+  { grossAnnualIncome: 90_000, nics: 3810.32 },
+  { grossAnnualIncome: 110_000, nics: 4210.32 },
+  { grossAnnualIncome: 130_000, nics: 4610.32 },
+  { grossAnnualIncome: 150_000, nics: 5010.32 },
+  { grossAnnualIncome: 175_000, nics: 5510.32 },
+  { grossAnnualIncome: 200_000, nics: 6010.32 },
+  { grossAnnualIncome: 250_000, nics: 7010.32 },
+  { grossAnnualIncome: 500_000, nics: 12010.32 },
+  { grossAnnualIncome: 1_000_000, nics: 22010.32 },
 ];
 
 describe("calculateEmployeeNationalInsurance (24/25)", () => {
   expectationsC.forEach((expectation) => {
-    const { taxableAnnualIncome, nics } = expectation;
-    test(taxableAnnualIncome.toString(), () => {
+    const { grossAnnualIncome, nics } = expectation;
+    test(grossAnnualIncome.toString(), () => {
       expect(
         calculateEmployeeNationalInsurance({
           taxYear: "2024/25",
-          taxableAnnualIncome,
+          grossAnnualIncome,
         })
       ).toBeCloseTo(nics, 1);
     });
@@ -110,24 +110,24 @@ describe("calculateEmployeeNationalInsurance (24/25)", () => {
 
 // Employer NI (Class 1, Category A): 13.8% above £175/week secondary threshold
 const employerExpectations2425 = [
-  { taxableAnnualIncome: 9_100, nics: 0 }, // at secondary threshold (£175/week × 52)
-  { taxableAnnualIncome: 10_000, nics: 124.2 }, // (10000 - 9100) × 13.8%
-  { taxableAnnualIncome: 20_000, nics: 1504.2 },
-  { taxableAnnualIncome: 30_000, nics: 2884.2 },
-  { taxableAnnualIncome: 50_000, nics: 5644.2 },
-  { taxableAnnualIncome: 75_000, nics: 9094.2 },
-  { taxableAnnualIncome: 100_000, nics: 12544.2 },
-  { taxableAnnualIncome: 150_000, nics: 19444.2 },
+  { grossAnnualIncome: 9_100, nics: 0 }, // at secondary threshold (£175/week × 52)
+  { grossAnnualIncome: 10_000, nics: 124.2 }, // (10000 - 9100) × 13.8%
+  { grossAnnualIncome: 20_000, nics: 1504.2 },
+  { grossAnnualIncome: 30_000, nics: 2884.2 },
+  { grossAnnualIncome: 50_000, nics: 5644.2 },
+  { grossAnnualIncome: 75_000, nics: 9094.2 },
+  { grossAnnualIncome: 100_000, nics: 12544.2 },
+  { grossAnnualIncome: 150_000, nics: 19444.2 },
 ];
 
 describe("calculateEmployerNationalInsurance (24/25)", () => {
   employerExpectations2425.forEach((expectation) => {
-    const { taxableAnnualIncome, nics } = expectation;
-    test(taxableAnnualIncome.toString(), () => {
+    const { grossAnnualIncome, nics } = expectation;
+    test(grossAnnualIncome.toString(), () => {
       expect(
         calculateEmployerNationalInsurance({
           taxYear: "2024/25",
-          taxableAnnualIncome,
+          grossAnnualIncome,
         })
       ).toBeCloseTo(nics, 1);
     });
@@ -136,24 +136,24 @@ describe("calculateEmployerNationalInsurance (24/25)", () => {
 
 // Employer NI (Class 1, Category A): 15% above £96/week secondary threshold (from April 2025)
 const employerExpectations2526 = [
-  { taxableAnnualIncome: 4_992, nics: 0 }, // at secondary threshold (£96/week × 52)
-  { taxableAnnualIncome: 10_000, nics: 751.2 }, // (10000 - 4992) × 15%
-  { taxableAnnualIncome: 20_000, nics: 2251.2 },
-  { taxableAnnualIncome: 30_000, nics: 3751.2 },
-  { taxableAnnualIncome: 50_000, nics: 6751.2 },
-  { taxableAnnualIncome: 75_000, nics: 10501.2 },
-  { taxableAnnualIncome: 100_000, nics: 14251.2 },
-  { taxableAnnualIncome: 150_000, nics: 21751.2 },
+  { grossAnnualIncome: 4_992, nics: 0 }, // at secondary threshold (£96/week × 52)
+  { grossAnnualIncome: 10_000, nics: 751.2 }, // (10000 - 4992) × 15%
+  { grossAnnualIncome: 20_000, nics: 2251.2 },
+  { grossAnnualIncome: 30_000, nics: 3751.2 },
+  { grossAnnualIncome: 50_000, nics: 6751.2 },
+  { grossAnnualIncome: 75_000, nics: 10501.2 },
+  { grossAnnualIncome: 100_000, nics: 14251.2 },
+  { grossAnnualIncome: 150_000, nics: 21751.2 },
 ];
 
 describe("calculateEmployerNationalInsurance (25/26)", () => {
   employerExpectations2526.forEach((expectation) => {
-    const { taxableAnnualIncome, nics } = expectation;
-    test(taxableAnnualIncome.toString(), () => {
+    const { grossAnnualIncome, nics } = expectation;
+    test(grossAnnualIncome.toString(), () => {
       expect(
         calculateEmployerNationalInsurance({
           taxYear: "2025/26",
-          taxableAnnualIncome,
+          grossAnnualIncome,
         })
       ).toBeCloseTo(nics, 1);
     });

--- a/src/nationalInsurance.ts
+++ b/src/nationalInsurance.ts
@@ -2,20 +2,21 @@ import { getHmrcRates } from "./hmrc";
 
 import type { TaxYear, Country } from "./types";
 
-// Calculates an individual's national insurance contributions based on taxable income.
+// Calculates an individual's national insurance contributions based on gross employment income.
+// Pass gross PAYE employment income — NI is not reduced by non-salary-sacrifice pension contributions.
 // Supports class 1, category A employee national insurance only.
 // Uses the employee's weekly salary as a basis, as per the system, then re-converts into a year at the end.
 // See https://www.gov.uk/national-insurance-rates-letters/category-letters for other categories
 export const calculateEmployeeNationalInsurance = ({
   taxYear,
   country,
-  taxableAnnualIncome,
+  grossAnnualIncome,
 }: {
   taxYear?: TaxYear;
   country?: Country;
-  taxableAnnualIncome: number;
+  grossAnnualIncome: number;
 }) => {
-  const weeklySalary = taxableAnnualIncome / 52;
+  const weeklySalary = grossAnnualIncome / 52;
   const { NI_MIDDLE_RATE, NI_UPPER_RATE, NI_MIDDLE_BRACKET, NI_UPPER_BRACKET } =
     getHmrcRates({ taxYear, country });
   const afterFreeSection = weeklySalary - NI_MIDDLE_BRACKET;
@@ -37,20 +38,21 @@ export const calculateEmployeeNationalInsurance = ({
   return (middleBracket + upperBracket) * 52;
 };
 
-// Calculates employer national insurance contributions based on an employee's taxable income.
+// Calculates employer national insurance contributions based on an employee's gross employment income.
+// Pass gross PAYE employment income — NI is not reduced by non-salary-sacrifice pension contributions.
 // Supports class 1, category A secondary contributions only.
 // Uses the employee's weekly salary as a basis, as per the system, then re-converts into a year at the end.
 // See https://www.gov.uk/national-insurance-rates-letters/category-letters for other categories
 export const calculateEmployerNationalInsurance = ({
   taxYear,
   country,
-  taxableAnnualIncome,
+  grossAnnualIncome,
 }: {
   taxYear?: TaxYear;
   country?: Country;
-  taxableAnnualIncome: number;
+  grossAnnualIncome: number;
 }) => {
-  const weeklySalary = taxableAnnualIncome / 52;
+  const weeklySalary = grossAnnualIncome / 52;
   const { EMPLOYER_NI_RATE, EMPLOYER_NI_SECONDARY_THRESHOLD } = getHmrcRates({
     taxYear,
     country,

--- a/src/studentLoan.test.ts
+++ b/src/studentLoan.test.ts
@@ -2,38 +2,38 @@ import { calculateStudentLoanRepayments } from "./studentLoan";
 
 describe("calculateStudentLoanRepayments", () => {
   const expectationsPlan1 = [
-    { taxableAnnualIncome: 15_000, repayments: 0 },
-    { taxableAnnualIncome: 17_500, repayments: 0 },
-    { taxableAnnualIncome: 20_000, repayments: 0 },
-    { taxableAnnualIncome: 22_500, repayments: 209.1599999999999 },
-    { taxableAnnualIncome: 25_000, repayments: 434.16 },
-    { taxableAnnualIncome: 50_000, repayments: 2684.16 },
-    { taxableAnnualIncome: 55_000, repayments: 3134.1599999999994 },
-    { taxableAnnualIncome: 60_000, repayments: 3584.1599999999994 },
-    { taxableAnnualIncome: 75_000, repayments: 4934.16 },
-    { taxableAnnualIncome: 90_000, repayments: 6284.16 },
-    { taxableAnnualIncome: 110_000, repayments: 8084.159999999999 },
-    { taxableAnnualIncome: 120_000, repayments: 8984.16 },
-    { taxableAnnualIncome: 124_500, repayments: 9389.16 },
-    { taxableAnnualIncome: 125_000, repayments: 9434.159999999998 },
-    { taxableAnnualIncome: 130_000, repayments: 9884.16 },
-    { taxableAnnualIncome: 145_000, repayments: 11234.16 },
-    { taxableAnnualIncome: 160_000, repayments: 12584.160000000002 },
-    { taxableAnnualIncome: 175_000, repayments: 13934.159999999998 },
-    { taxableAnnualIncome: 200_000, repayments: 16184.160000000002 },
-    { taxableAnnualIncome: 250_000, repayments: 20684.16 },
-    { taxableAnnualIncome: 500_000, repayments: 43184.159999999996 },
-    { taxableAnnualIncome: 1_000_000, repayments: 88184.15999999999 },
+    { grossAnnualIncome: 15_000, repayments: 0 },
+    { grossAnnualIncome: 17_500, repayments: 0 },
+    { grossAnnualIncome: 20_000, repayments: 0 },
+    { grossAnnualIncome: 22_500, repayments: 209.1599999999999 },
+    { grossAnnualIncome: 25_000, repayments: 434.16 },
+    { grossAnnualIncome: 50_000, repayments: 2684.16 },
+    { grossAnnualIncome: 55_000, repayments: 3134.1599999999994 },
+    { grossAnnualIncome: 60_000, repayments: 3584.1599999999994 },
+    { grossAnnualIncome: 75_000, repayments: 4934.16 },
+    { grossAnnualIncome: 90_000, repayments: 6284.16 },
+    { grossAnnualIncome: 110_000, repayments: 8084.159999999999 },
+    { grossAnnualIncome: 120_000, repayments: 8984.16 },
+    { grossAnnualIncome: 124_500, repayments: 9389.16 },
+    { grossAnnualIncome: 125_000, repayments: 9434.159999999998 },
+    { grossAnnualIncome: 130_000, repayments: 9884.16 },
+    { grossAnnualIncome: 145_000, repayments: 11234.16 },
+    { grossAnnualIncome: 160_000, repayments: 12584.160000000002 },
+    { grossAnnualIncome: 175_000, repayments: 13934.159999999998 },
+    { grossAnnualIncome: 200_000, repayments: 16184.160000000002 },
+    { grossAnnualIncome: 250_000, repayments: 20684.16 },
+    { grossAnnualIncome: 500_000, repayments: 43184.159999999996 },
+    { grossAnnualIncome: 1_000_000, repayments: 88184.15999999999 },
   ];
 
   describe("Plan 1 loans", () => {
     expectationsPlan1.forEach((expectation) => {
-      const { taxableAnnualIncome, repayments } = expectation;
-      test(taxableAnnualIncome.toString(), () => {
+      const { grossAnnualIncome, repayments } = expectation;
+      test(grossAnnualIncome.toString(), () => {
         expect(
           calculateStudentLoanRepayments({
             taxYear: "2022/23",
-            taxableAnnualIncome,
+            grossAnnualIncome,
             studentLoanPlanNo: 1,
           })
         ).toEqual(repayments);
@@ -42,38 +42,38 @@ describe("calculateStudentLoanRepayments", () => {
   });
 
   const expectationsPlan2 = [
-    { taxableAnnualIncome: 15_000, repayments: 0 },
-    { taxableAnnualIncome: 17_500, repayments: 0 },
-    { taxableAnnualIncome: 20_000, repayments: 0 },
-    { taxableAnnualIncome: 22_500, repayments: 0 },
-    { taxableAnnualIncome: 25_000, repayments: 0 },
-    { taxableAnnualIncome: 50_000, repayments: 2047.6799999999998 },
-    { taxableAnnualIncome: 55_000, repayments: 2497.6799999999994 },
-    { taxableAnnualIncome: 60_000, repayments: 2947.68 },
-    { taxableAnnualIncome: 75_000, repayments: 4297.68 },
-    { taxableAnnualIncome: 90_000, repayments: 5647.679999999999 },
-    { taxableAnnualIncome: 110_000, repayments: 7447.6799999999985 },
-    { taxableAnnualIncome: 120_000, repayments: 8347.68 },
-    { taxableAnnualIncome: 124_500, repayments: 8752.679999999998 },
-    { taxableAnnualIncome: 125_000, repayments: 8797.68 },
-    { taxableAnnualIncome: 130_000, repayments: 9247.68 },
-    { taxableAnnualIncome: 145_000, repayments: 10597.68 },
-    { taxableAnnualIncome: 160_000, repayments: 11947.68 },
-    { taxableAnnualIncome: 175_000, repayments: 13297.679999999998 },
-    { taxableAnnualIncome: 200_000, repayments: 15547.68 },
-    { taxableAnnualIncome: 250_000, repayments: 20047.679999999997 },
-    { taxableAnnualIncome: 500_000, repayments: 42547.68 },
-    { taxableAnnualIncome: 1_000_000, repayments: 87547.68 },
+    { grossAnnualIncome: 15_000, repayments: 0 },
+    { grossAnnualIncome: 17_500, repayments: 0 },
+    { grossAnnualIncome: 20_000, repayments: 0 },
+    { grossAnnualIncome: 22_500, repayments: 0 },
+    { grossAnnualIncome: 25_000, repayments: 0 },
+    { grossAnnualIncome: 50_000, repayments: 2047.6799999999998 },
+    { grossAnnualIncome: 55_000, repayments: 2497.6799999999994 },
+    { grossAnnualIncome: 60_000, repayments: 2947.68 },
+    { grossAnnualIncome: 75_000, repayments: 4297.68 },
+    { grossAnnualIncome: 90_000, repayments: 5647.679999999999 },
+    { grossAnnualIncome: 110_000, repayments: 7447.6799999999985 },
+    { grossAnnualIncome: 120_000, repayments: 8347.68 },
+    { grossAnnualIncome: 124_500, repayments: 8752.679999999998 },
+    { grossAnnualIncome: 125_000, repayments: 8797.68 },
+    { grossAnnualIncome: 130_000, repayments: 9247.68 },
+    { grossAnnualIncome: 145_000, repayments: 10597.68 },
+    { grossAnnualIncome: 160_000, repayments: 11947.68 },
+    { grossAnnualIncome: 175_000, repayments: 13297.679999999998 },
+    { grossAnnualIncome: 200_000, repayments: 15547.68 },
+    { grossAnnualIncome: 250_000, repayments: 20047.679999999997 },
+    { grossAnnualIncome: 500_000, repayments: 42547.68 },
+    { grossAnnualIncome: 1_000_000, repayments: 87547.68 },
   ];
 
   describe("Plan 2 loans", () => {
     expectationsPlan2.forEach((expectation) => {
-      const { taxableAnnualIncome, repayments } = expectation;
-      test(taxableAnnualIncome.toString(), () => {
+      const { grossAnnualIncome, repayments } = expectation;
+      test(grossAnnualIncome.toString(), () => {
         expect(
           calculateStudentLoanRepayments({
             taxYear: "2022/23",
-            taxableAnnualIncome,
+            grossAnnualIncome,
             studentLoanPlanNo: 2,
           })
         ).toEqual(repayments);
@@ -82,38 +82,38 @@ describe("calculateStudentLoanRepayments", () => {
   });
 
   const expectationsPlan4 = [
-    { taxableAnnualIncome: 15_000, repayments: 0 },
-    { taxableAnnualIncome: 17_500, repayments: 0 },
-    { taxableAnnualIncome: 20_000, repayments: 0 },
-    { taxableAnnualIncome: 22_500, repayments: 0 },
-    { taxableAnnualIncome: 25_000, repayments: 0 },
-    { taxableAnnualIncome: 50_000, repayments: 2216.2536 },
-    { taxableAnnualIncome: 55_000, repayments: 2666.2535999999996 },
-    { taxableAnnualIncome: 60_000, repayments: 3116.2535999999996 },
-    { taxableAnnualIncome: 75_000, repayments: 4466.2536 },
-    { taxableAnnualIncome: 90_000, repayments: 5816.2536 },
-    { taxableAnnualIncome: 110_000, repayments: 7616.253599999999 },
-    { taxableAnnualIncome: 120_000, repayments: 8516.253599999998 },
-    { taxableAnnualIncome: 124_500, repayments: 8921.2536 },
-    { taxableAnnualIncome: 125_000, repayments: 8966.253599999998 },
-    { taxableAnnualIncome: 130_000, repayments: 9416.2536 },
-    { taxableAnnualIncome: 145_000, repayments: 10766.2536 },
-    { taxableAnnualIncome: 160_000, repayments: 12116.2536 },
-    { taxableAnnualIncome: 175_000, repayments: 13466.253599999998 },
-    { taxableAnnualIncome: 200_000, repayments: 15716.253599999998 },
-    { taxableAnnualIncome: 250_000, repayments: 20216.253599999996 },
-    { taxableAnnualIncome: 500_000, repayments: 42716.253600000004 },
-    { taxableAnnualIncome: 1_000_000, repayments: 87716.2536 },
+    { grossAnnualIncome: 15_000, repayments: 0 },
+    { grossAnnualIncome: 17_500, repayments: 0 },
+    { grossAnnualIncome: 20_000, repayments: 0 },
+    { grossAnnualIncome: 22_500, repayments: 0 },
+    { grossAnnualIncome: 25_000, repayments: 0 },
+    { grossAnnualIncome: 50_000, repayments: 2216.2536 },
+    { grossAnnualIncome: 55_000, repayments: 2666.2535999999996 },
+    { grossAnnualIncome: 60_000, repayments: 3116.2535999999996 },
+    { grossAnnualIncome: 75_000, repayments: 4466.2536 },
+    { grossAnnualIncome: 90_000, repayments: 5816.2536 },
+    { grossAnnualIncome: 110_000, repayments: 7616.253599999999 },
+    { grossAnnualIncome: 120_000, repayments: 8516.253599999998 },
+    { grossAnnualIncome: 124_500, repayments: 8921.2536 },
+    { grossAnnualIncome: 125_000, repayments: 8966.253599999998 },
+    { grossAnnualIncome: 130_000, repayments: 9416.2536 },
+    { grossAnnualIncome: 145_000, repayments: 10766.2536 },
+    { grossAnnualIncome: 160_000, repayments: 12116.2536 },
+    { grossAnnualIncome: 175_000, repayments: 13466.253599999998 },
+    { grossAnnualIncome: 200_000, repayments: 15716.253599999998 },
+    { grossAnnualIncome: 250_000, repayments: 20216.253599999996 },
+    { grossAnnualIncome: 500_000, repayments: 42716.253600000004 },
+    { grossAnnualIncome: 1_000_000, repayments: 87716.2536 },
   ];
 
   describe("Plan 4 loans", () => {
     expectationsPlan4.forEach((expectation) => {
-      const { taxableAnnualIncome, repayments } = expectation;
-      test(taxableAnnualIncome.toString(), () => {
+      const { grossAnnualIncome, repayments } = expectation;
+      test(grossAnnualIncome.toString(), () => {
         expect(
           calculateStudentLoanRepayments({
             taxYear: "2022/23",
-            taxableAnnualIncome,
+            grossAnnualIncome,
             studentLoanPlanNo: 4,
           })
         ).toEqual(repayments);
@@ -122,38 +122,38 @@ describe("calculateStudentLoanRepayments", () => {
   });
 
   const expectationsPlan5 = [
-    { taxableAnnualIncome: 15_000, repayments: 0 },
-    { taxableAnnualIncome: 17_500, repayments: 0 },
-    { taxableAnnualIncome: 20_000, repayments: 0 },
-    { taxableAnnualIncome: 22_500, repayments: 0 },
-    { taxableAnnualIncome: 25_000, repayments: 3.6000000000000205 },
-    { taxableAnnualIncome: 50_000, repayments: 2253.6 },
-    { taxableAnnualIncome: 55_000, repayments: 2703.5999999999995 },
-    { taxableAnnualIncome: 60_000, repayments: 3153.6 },
-    { taxableAnnualIncome: 75_000, repayments: 4503.599999999999 },
-    { taxableAnnualIncome: 90_000, repayments: 5853.599999999999 },
-    { taxableAnnualIncome: 110_000, repayments: 7653.599999999999 },
-    { taxableAnnualIncome: 120_000, repayments: 8553.6 },
-    { taxableAnnualIncome: 124_500, repayments: 8958.599999999999 },
-    { taxableAnnualIncome: 125_000, repayments: 9003.599999999999 },
-    { taxableAnnualIncome: 130_000, repayments: 9453.599999999999 },
-    { taxableAnnualIncome: 145_000, repayments: 10803.6 },
-    { taxableAnnualIncome: 160_000, repayments: 12153.6 },
-    { taxableAnnualIncome: 175_000, repayments: 13503.599999999999 },
-    { taxableAnnualIncome: 200_000, repayments: 15753.599999999999 },
-    { taxableAnnualIncome: 250_000, repayments: 20253.6 },
-    { taxableAnnualIncome: 500_000, repayments: 42753.6 },
-    { taxableAnnualIncome: 1_000_000, repayments: 87753.59999999999 },
+    { grossAnnualIncome: 15_000, repayments: 0 },
+    { grossAnnualIncome: 17_500, repayments: 0 },
+    { grossAnnualIncome: 20_000, repayments: 0 },
+    { grossAnnualIncome: 22_500, repayments: 0 },
+    { grossAnnualIncome: 25_000, repayments: 3.6000000000000205 },
+    { grossAnnualIncome: 50_000, repayments: 2253.6 },
+    { grossAnnualIncome: 55_000, repayments: 2703.5999999999995 },
+    { grossAnnualIncome: 60_000, repayments: 3153.6 },
+    { grossAnnualIncome: 75_000, repayments: 4503.599999999999 },
+    { grossAnnualIncome: 90_000, repayments: 5853.599999999999 },
+    { grossAnnualIncome: 110_000, repayments: 7653.599999999999 },
+    { grossAnnualIncome: 120_000, repayments: 8553.6 },
+    { grossAnnualIncome: 124_500, repayments: 8958.599999999999 },
+    { grossAnnualIncome: 125_000, repayments: 9003.599999999999 },
+    { grossAnnualIncome: 130_000, repayments: 9453.599999999999 },
+    { grossAnnualIncome: 145_000, repayments: 10803.6 },
+    { grossAnnualIncome: 160_000, repayments: 12153.6 },
+    { grossAnnualIncome: 175_000, repayments: 13503.599999999999 },
+    { grossAnnualIncome: 200_000, repayments: 15753.599999999999 },
+    { grossAnnualIncome: 250_000, repayments: 20253.6 },
+    { grossAnnualIncome: 500_000, repayments: 42753.6 },
+    { grossAnnualIncome: 1_000_000, repayments: 87753.59999999999 },
   ];
 
   describe("Plan 5 loans", () => {
     expectationsPlan5.forEach((expectation) => {
-      const { taxableAnnualIncome, repayments } = expectation;
-      test(taxableAnnualIncome.toString(), () => {
+      const { grossAnnualIncome, repayments } = expectation;
+      test(grossAnnualIncome.toString(), () => {
         expect(
           calculateStudentLoanRepayments({
             taxYear: "2022/23",
-            taxableAnnualIncome,
+            grossAnnualIncome,
             studentLoanPlanNo: 5,
           })
         ).toEqual(repayments);
@@ -162,38 +162,38 @@ describe("calculateStudentLoanRepayments", () => {
   });
 
   const expectationsPostgrad = [
-    { taxableAnnualIncome: 15_000, repayments: 0 },
-    { taxableAnnualIncome: 17_500, repayments: 0 },
-    { taxableAnnualIncome: 20_000, repayments: 0 },
-    { taxableAnnualIncome: 22_500, repayments: 90.01920000000004 },
-    { taxableAnnualIncome: 25_000, repayments: 240.0192000000001 },
-    { taxableAnnualIncome: 50_000, repayments: 1740.0192 },
-    { taxableAnnualIncome: 55_000, repayments: 2040.0192000000002 },
-    { taxableAnnualIncome: 60_000, repayments: 2340.0192 },
-    { taxableAnnualIncome: 75_000, repayments: 3240.0192 },
-    { taxableAnnualIncome: 90_000, repayments: 4140.019200000001 },
-    { taxableAnnualIncome: 110_000, repayments: 5340.0192 },
-    { taxableAnnualIncome: 120_000, repayments: 5940.0192 },
-    { taxableAnnualIncome: 124_500, repayments: 6210.0192 },
-    { taxableAnnualIncome: 125_000, repayments: 6240.0192 },
-    { taxableAnnualIncome: 130_000, repayments: 6540.019199999999 },
-    { taxableAnnualIncome: 145_000, repayments: 7440.019199999999 },
-    { taxableAnnualIncome: 160_000, repayments: 8340.019199999999 },
-    { taxableAnnualIncome: 175_000, repayments: 9240.019199999999 },
-    { taxableAnnualIncome: 200_000, repayments: 10740.019199999999 },
-    { taxableAnnualIncome: 250_000, repayments: 13740.019199999999 },
-    { taxableAnnualIncome: 500_000, repayments: 28740.0192 },
-    { taxableAnnualIncome: 1_000_000, repayments: 58740.01919999999 },
+    { grossAnnualIncome: 15_000, repayments: 0 },
+    { grossAnnualIncome: 17_500, repayments: 0 },
+    { grossAnnualIncome: 20_000, repayments: 0 },
+    { grossAnnualIncome: 22_500, repayments: 90.01920000000004 },
+    { grossAnnualIncome: 25_000, repayments: 240.0192000000001 },
+    { grossAnnualIncome: 50_000, repayments: 1740.0192 },
+    { grossAnnualIncome: 55_000, repayments: 2040.0192000000002 },
+    { grossAnnualIncome: 60_000, repayments: 2340.0192 },
+    { grossAnnualIncome: 75_000, repayments: 3240.0192 },
+    { grossAnnualIncome: 90_000, repayments: 4140.019200000001 },
+    { grossAnnualIncome: 110_000, repayments: 5340.0192 },
+    { grossAnnualIncome: 120_000, repayments: 5940.0192 },
+    { grossAnnualIncome: 124_500, repayments: 6210.0192 },
+    { grossAnnualIncome: 125_000, repayments: 6240.0192 },
+    { grossAnnualIncome: 130_000, repayments: 6540.019199999999 },
+    { grossAnnualIncome: 145_000, repayments: 7440.019199999999 },
+    { grossAnnualIncome: 160_000, repayments: 8340.019199999999 },
+    { grossAnnualIncome: 175_000, repayments: 9240.019199999999 },
+    { grossAnnualIncome: 200_000, repayments: 10740.019199999999 },
+    { grossAnnualIncome: 250_000, repayments: 13740.019199999999 },
+    { grossAnnualIncome: 500_000, repayments: 28740.0192 },
+    { grossAnnualIncome: 1_000_000, repayments: 58740.01919999999 },
   ];
 
   describe("Postgrad loans", () => {
     expectationsPostgrad.forEach((expectation) => {
-      const { taxableAnnualIncome, repayments } = expectation;
-      test(taxableAnnualIncome.toString(), () => {
+      const { grossAnnualIncome, repayments } = expectation;
+      test(grossAnnualIncome.toString(), () => {
         expect(
           calculateStudentLoanRepayments({
             taxYear: "2022/23",
-            taxableAnnualIncome,
+            grossAnnualIncome,
             studentLoanPlanNo: "postgrad",
           })
         ).toEqual(repayments);

--- a/src/studentLoan.ts
+++ b/src/studentLoan.ts
@@ -3,16 +3,17 @@ import { getHmrcRates } from "./hmrc";
 import type { StudentLoanPlan, TaxYear, Country } from "./types";
 
 // Calculates an individual's annual student loan repayments
+// Pass gross PAYE employment income — student loan repayments are calculated on gross income, not reduced by non-salary-sacrifice pension contributions.
 // Note that student loan repayments do not take into account the personal allowance in any way, it's a simple threshold system
 export const calculateStudentLoanRepayments = ({
   taxYear,
   country,
-  taxableAnnualIncome,
+  grossAnnualIncome,
   studentLoanPlanNo,
 }: {
   taxYear?: TaxYear;
   country?: Country;
-  taxableAnnualIncome: number;
+  grossAnnualIncome: number;
   studentLoanPlanNo: StudentLoanPlan;
 }): number => {
   const {
@@ -58,7 +59,7 @@ export const calculateStudentLoanRepayments = ({
     }
   }
 
-  const weeklySalary = taxableAnnualIncome / 52;
+  const weeklySalary = grossAnnualIncome / 52;
   const repaymentAmount =
     studentLoanPlanNo === "postgrad"
       ? STUDENT_LOAN_REPAYMENT_AMOUNT_POSTGRAD


### PR DESCRIPTION
Resolves #20

**Summary**

Fixes a misleading parameter name in `calculateEmployeeNationalInsurance`, `calculateEmployerNationalInsurance`, and `calculateStudentLoanRepayments`. The previous name `taxableAnnualIncome` implied these functions should receive the same post-deduction income figure as `calculateIncomeTax`, which is incorrect for users with non-salary-sacrifice pension contributions.

**What's changed**

- Renamed `taxableAnnualIncome` → `grossAnnualIncome` in `calculateEmployeeNationalInsurance`, `calculateEmployerNationalInsurance`, and `calculateStudentLoanRepayments`

**Why**

NI and student loan repayments are calculated on gross earnings, not taxable income. For a user with a £60k salary making non-salary-sacrifice pension contributions (e.g. 3% = £1,800), the correct inputs are:

| Function | Correct value |
|---|---|
| `calculateIncomeTax` | £58,200 (post-pension taxable income) |
| `calculateEmployeeNationalInsurance` | £60,000 (gross employment income) |
| `calculateStudentLoanRepayments` | £60,000 (gross employment income) |

The old parameter name caused a natural but incorrect assumption that all three functions take the same value. For salary sacrifice arrangements the values coincidentally align (sacrifice reduces gross PAYE income across the board), but for the more common relief-at-source case they differ.

**Breaking change**

Callers passing named parameters will need to update their call sites — e.g. `{ taxableAnnualIncome: 60000 }` → `{ grossAnnualIncome: 60000 }`. No calculation logic has changed.
